### PR TITLE
fixes #25 adjust animation for locationName

### DIFF
--- a/tags/wake-header.tag
+++ b/tags/wake-header.tag
@@ -1,7 +1,7 @@
 <wake-header>
   <header class={ dead:opts.dead }>
     <btn click={ wakeUp }>Wake Up</btn>
-    <h1 id="locationName" class="animated fadeIn">{ tba.currentRoom.name }</h1>
+    <h1 id="locationName" class="animated fadeIn">{ name }</h1>
     <small id="hintElm" class="animated fadeIn" if={ hint.length }>{ hint }</small>
     <nav class="menu">
       <a onclick={ reset }>reset</a>
@@ -48,6 +48,7 @@
   <script type=babel>
     var hint = '';
     var hintTimeout;
+    var loaded = false;
     this.mixin('tba');
     this.mixin('storage');
 
@@ -81,14 +82,24 @@
       hintTimeout = setTimeout(this.clearHint, timeout);
     });
 
+    var locationAnimationEvent = () => {
+      this.name = this.tba.currentRoom.name;
+      this.update();
+      this.locationName.classList.remove("fadeOut");
+      this.locationName.classList.add("fadeIn");
+      this.locationName.removeEventListener('animationend', locationAnimationEvent, false);
+    };
+
     this.tba.on('roomChange', () => {
-      this.locationName.addEventListener("animationend", () => { 
+      if (loaded) {
+        this.locationName.addEventListener("animationend", locationAnimationEvent, false);
+        this.locationName.classList.remove("fadeIn");
+        this.locationName.classList.add("fadeOut");
+      } else {
+        this.name = this.tba.currentRoom.name;
         this.update();
-        this.locationName.classList.remove("fadeOut");
-        this.locationName.classList.add("fadeIn");
-      }, false);
-      this.locationName.classList.remove("fadeIn");
-      this.locationName.classList.add("fadeOut");
+        loaded = true;
+      }
     });
 
     this.reset = function(){


### PR DESCRIPTION
fixes #25 
adjust animation for locationName in the header riot tag.
Animation now show up properly on refresh and will always fadeout before changing names.